### PR TITLE
Use BitSet from its own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "linear_assignment"
 [dependencies]
 num = "0.1.24"
 log = "0.3"
+bit-set = "0.5.0"
 
 
 [dev-dependencies.nalgebra]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ name = "linear_assignment"
 
 
 [dependencies]
-num = "0.1.24"
-log = "0.3"
+num = "0.2"
+log = "0.4"
 bit-set = "0.5.0"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ bit-set = "0.5.0"
 
 
 [dev-dependencies.nalgebra]
-version = "0.2.14"
-features = ["quickcheck", "arbitrary"]
+version = "0.16"
+features = ["arbitrary"]
 
 [dev-dependencies.rand]
 version = "*"
 
 [dev-dependencies.quickcheck]
-version = "0.2.18"
+version = "0.6"
 
 [dev-dependencies.quickcheck_macros]
-version = "0.2.18"
+version = "0.7"
 
 [dev-dependencies.env_logger]
 version = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(collections)]
 //! This is a library for solving the [linear assignment
 //! problem](http://en.wikipedia.org/wiki/Assignment_problem).
 //! For this problem, it is helpful to think of the data as a [bipartite
@@ -26,11 +25,12 @@ use std::ops::Add;
 use std::ops::Sub;
 use std::cmp;
 use std::collections::HashSet;
-use std::collections::BitSet;
 
 extern crate num;
+extern crate bit_set;
 
 use num::Zero;
+use bit_set::BitSet;
 
 #[macro_use]
 extern crate log;
@@ -180,7 +180,7 @@ fn prime_zeros(zeros: Vec<Edge>, columns_covered: &mut BitSet, rows_covered: &mu
                     info!("Found starred zero in row of new prime.");
                     // cover this row, uncover this column
                     rows_covered.insert(edge_to_prime.0);
-                    columns_covered.remove(&edge_to_prime.1);
+                    columns_covered.remove(edge_to_prime.1);
                 } else {
                     let path = find_alternating_path(edge_to_prime, &*stars, &*primes);
                     *stars = get_stars_from_path(path, &*stars);
@@ -216,7 +216,7 @@ fn adjust_weights<T>(matrix: &mut T, size: &MatrixSize, columns_covered: &mut Bi
     }
 
     for column in 0..size.columns {
-        if !columns_covered.contains(&column) {
+        if !columns_covered.contains(column) {
             for row in 0..size.rows {
                 matrix[(row, column)] = matrix[(row, column)] - smallest;
                 debug_assert!(matrix[(row, column)] >= T::Output::zero());
@@ -228,7 +228,7 @@ fn adjust_weights<T>(matrix: &mut T, size: &MatrixSize, columns_covered: &mut Bi
 
 fn all_stars_covered(stars: &HashSet<Edge>, columns_covered: &BitSet, rows_covered: &BitSet) -> bool {
     for &(row, column) in stars.iter() {
-        if !rows_covered.contains(&row) && !columns_covered.contains(&column) {
+        if !rows_covered.contains(row) && !columns_covered.contains(column) {
             return false;
         }
     }
@@ -239,7 +239,7 @@ fn all_stars_covered(stars: &HashSet<Edge>, columns_covered: &BitSet, rows_cover
 fn find_uncovered_zero(zeros: &Vec<Edge>, 
                        columns_covered: &BitSet, rows_covered: &BitSet) -> Option<Edge> {
     for &(row, column) in zeros {
-        if !rows_covered.contains(&row) && !columns_covered.contains(&column) {
+        if !rows_covered.contains(row) && !columns_covered.contains(column) {
             return Some((row, column));
         }
     }
@@ -275,9 +275,9 @@ fn find_smallest_uncovered<T>(matrix: &T, size: &MatrixSize,
     let mut smallest = None;
 
     for row in 0..size.rows {
-        if !rows_covered.contains(&row) {
+        if !rows_covered.contains(row) {
             for column in 0..size.columns {
-                if !columns_covered.contains(&column) {
+                if !columns_covered.contains(column) {
                     debug_assert!(matrix[(row, column)] > T::Output::zero());
                     smallest = match smallest {
                         Some(smaller) => Some(cmp::min(smaller, matrix[(row, column)])),
@@ -417,7 +417,7 @@ fn initial_stars(zeros: &Vec<Edge>) -> HashSet<Edge> {
 
 
     for &(row, column) in zeros {
-        if !columns.contains(&column) && !rows.contains(&row) {
+        if !columns.contains(column) && !rows.contains(row) {
             columns.insert(column);
             rows.insert(row);
             stars.insert((row, column));

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,3 @@
-#![feature(collections)]
 // Copyright (c) 2015 John Weaver and contributors.
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -22,9 +21,10 @@ extern crate rand;
 extern crate quickcheck;
 extern crate linear_assignment;
 extern crate env_logger;
+extern crate bit_set;
 
 use std::collections::HashSet;
-use std::collections::BitSet;
+use bit_set::BitSet;
 use std::cmp;
 use na::Transpose;
 use quickcheck::{TestResult};

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,7 +26,6 @@ extern crate bit_set;
 use std::collections::HashSet;
 use bit_set::BitSet;
 use std::cmp;
-use na::Transpose;
 use quickcheck::{TestResult};
 
 use linear_assignment::*;
@@ -38,20 +37,20 @@ trait LinearAssignmentProblem {
 }
 
 
-impl LinearAssignmentProblem for na::DMat<u32> {
+impl LinearAssignmentProblem for na::DMatrix<u32> {
     fn munkres(&self) -> HashSet<Edge> {
-        env_logger::init();
-
-        let mut matrix = &mut na::DMat::<u32>::new_zeros(self.nrows(), self.ncols());
-        matrix.clone_from(self);
         let transposed = self.nrows() > self.ncols();
-
-        if transposed {
-            matrix.transpose_mut();
-        }
+    
+        let mut matrix = {
+            if transposed {
+                self.transpose()
+            } else {
+                self.clone()
+            }
+        };
         let size = MatrixSize { rows: matrix.nrows(), columns: matrix.ncols() };
         assert!(size.columns >= size.rows);
-        let edges = solver::<na::DMat<u32>>(&mut matrix, &size);
+        let edges = solver::<na::DMatrix<u32>>(&mut matrix, &size);
         if transposed {
             edges.iter().map(|&(v, u)| (u, v)).collect()
         } else {
@@ -63,7 +62,7 @@ impl LinearAssignmentProblem for na::DMat<u32> {
 
 #[test]
 fn solve_1x1() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         1,
         1,
         &[0]
@@ -75,7 +74,7 @@ fn solve_1x1() {
 
 #[test]
 fn solve_2x2_case_1() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         2,
         2,
         &[1, 0,
@@ -89,7 +88,7 @@ fn solve_2x2_case_1() {
 
 #[test]
 fn solve_2x2_case_2() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         2,
         2,
         &[0, 1,
@@ -103,7 +102,7 @@ fn solve_2x2_case_2() {
 
 #[test]
 fn solve_3x3_case_1() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         3,
         3,
         &[1, 0, 1,
@@ -119,7 +118,7 @@ fn solve_3x3_case_1() {
 
 #[test]
 fn solve_3x2_case_1() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         3,
         2,
         &[1, 2,
@@ -135,7 +134,7 @@ fn solve_3x2_case_1() {
 
 #[test]
 fn solve_2x3_case_1() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         2,
         3,
         &[1, 0, 9,
@@ -150,7 +149,7 @@ fn solve_2x3_case_1() {
 
 #[test]
 fn solve_3x3_case_2() {
-    let test_matrix = na::DMat::from_row_vec(
+    let test_matrix = na::DMatrix::from_row_slice(
         3,
         3,
         &[ 1,  0,  9,
@@ -166,7 +165,7 @@ fn solve_3x3_case_2() {
 }
 
 #[quickcheck]
-fn number_of_results_is_k(matrix: na::DMat<u32>) -> TestResult {
+fn number_of_results_is_k(matrix: na::DMatrix<u32>) -> TestResult {
     if matrix.ncols() > 10 || matrix.nrows() > 10 {
         return TestResult::discard()
     }
@@ -178,7 +177,7 @@ fn number_of_results_is_k(matrix: na::DMat<u32>) -> TestResult {
 
 
 #[quickcheck]
-fn result_is_an_independent_set(matrix: na::DMat<u32>) -> TestResult {
+fn result_is_an_independent_set(matrix: na::DMatrix<u32>) -> TestResult {
     if matrix.ncols() > 10 || matrix.nrows() > 10 {
         return TestResult::discard()
     }
@@ -200,7 +199,7 @@ fn result_is_an_independent_set(matrix: na::DMat<u32>) -> TestResult {
 
 
 #[quickcheck]
-fn identical_results(matrix: na::DMat<u32>) -> TestResult {
+fn identical_results(matrix: na::DMatrix<u32>) -> TestResult {
     if matrix.ncols() > 10 || matrix.nrows() > 10 {
         return TestResult::discard()
     }


### PR DESCRIPTION
Hello,

The goal of this PR is to fix #4 .
Currently, the library builds but the tests don't. I believe this is due to incompatibilities between the (old) test dependencies and some of their own (newer) dependencies, due to some `dep = "*"` in their _Cargo.toml_.

I will try to find a working combination of dependencies versions, but this is not the quick and easy fix I expected, so help and feedback are very welcome. :)

Thomas